### PR TITLE
json encode request string before returning full generated request

### DIFF
--- a/learnosity_sdk/request.py
+++ b/learnosity_sdk/request.py
@@ -67,16 +67,16 @@ class Init(object):
 
         elif self.service == 'events':
             output['security'] = self.security
-            output['config'] = self.request_string
+            output['config'] = json.loads(self.request_string)
         elif self.service == 'assess':
             if self.request is not None:
-                output.update(self.request_string)
+                output.update(json.loads(self.request_string))
         elif self.service == 'data':
             # We ignore the encode param for data API
             output['security'] = json.dumps(self.security)
 
             if self.request is not None:
-                output['request'] = self.request_string
+                output['request'] = json.loads(self.request_string)
 
             if self.action is not None:
                 output['action'] = self.action
@@ -86,7 +86,7 @@ class Init(object):
             output['security'] = self.security
 
             if self.request is not None:
-                output['request'] = self.request_string
+                output['request'] = json.loads(self.request_string)
 
             if self.action is not None:
                 output['action'] = self.action


### PR DESCRIPTION
@ceralena could you take a look at this? Noticed a bug in the Python SDK for Items/Assess etc. where the request would always be a string of escaped JSON, rather than actually being JSON.