### PR TITLE
[BUG] Fix and document Events API initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Or just do a pull from GitHub and run again in the repo:
 
 # Usage
 
-Simple example:
+## Questions API
 
 ```python
 import learnosity_sdk.request
@@ -83,16 +83,16 @@ questions_request = {
     ]
 }
 
-init = learnosity_sdk.request.Init(
+questions_init = learnosity_sdk.request.Init(
     'questions', security, secret,
     request=questions_request
 )
 
 # Get the JSON that can be rendered into the page and passed to LearnosityApp.init
-signed_request = init.generate()
+signed_request = questions_init.generate()
 ```
 
-Data API example:
+## Data API
 
 ```python
 import json
@@ -137,6 +137,36 @@ print(len(items))
 for result in client.request_iter(endpoint, security, consumer_secret, data_request, action):
     # print the length of each page of the items list (will print a line for each page in the results)
     print(len(result['data']))
+```
+
+## Events API
+
+```python
+import learnosity_sdk.request
+
+# Security packet including consumer key
+security = {
+  'consumer_key': 'MY_API_KEY',
+  'domain': 'localhost',
+  'user_id': 'demo_student'
+}
+# consumer secret for API access
+# WARNING: The consumer secret should not be committed to source control.
+secret = 'MY_API_SECRET'
+
+# request data for Questions API
+events_request = {
+	"users": [ "diego", "manny", "sid"  ]
+}
+
+events_init = learnosity_sdk.request.Init(
+    'events', security, secret,
+    request=events_request
+)
+
+# Get the JSON that can be rendered into the page and passed to LearnosityApp.init
+signed_request = events_init.generate()
+print(signed_request)
 ```
 
 # Tests

--- a/learnosity_sdk/request/init.py
+++ b/learnosity_sdk/request/init.py
@@ -212,10 +212,10 @@ class Init(object):
             hashed_users = {}
             for user in self.request.get('users', []):
                 concat = "{}{}".format(user, self.secret)
-                hashed_users[user] = hashlib.sha256(concat)
+                hashed_users[user] = hashlib.sha256(concat.encode('utf-8')).hexdigest()
 
             if len(hashed_users) > 0:
-                self.request['users'] = hashed_users
+                self.security['users'] = hashed_users
 
     def hash_list(self, l):
         "Hash a list by concatenating values with an underscore"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
-import pip.req
+try: # for pip >= 10
+       from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+       from pip.req import parse_requirements
 import setuptools
 
 VERSION = '0.1.1'
 
 
 def test_reqs():
-    reqs = pip.req.parse_requirements('requirements-dev.txt', session=False)
+    reqs = parse_requirements('requirements-dev.txt', session=False)
     reqs = [str(ir.req) for ir in reqs]
 
     return reqs

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,7 +38,11 @@ ServiceTests = [
 
     ServiceTestSpec(
         "assess", True, None, {"foo": "bar"}
-    )
+    ),
+
+    ServiceTestSpec(
+        "events", True, None, {"users": [ "a", "b", "c" ] }
+    ),
 ]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ import unittest
 import learnosity_sdk.request
 
 ServiceTestSpec = collections.namedtuple(
-    "TestSpec", ["service", "valid", "security", "request"])
+    "TestSpec", ["service", "valid", "security", "request", "action", "signature"])
 
 ServiceTests = [
     ServiceTestSpec(
@@ -29,19 +29,102 @@ ServiceTests = [
                     }
                 }
             ]
-        }
+        }, None,
+        '0969eed4ca4bf483096393d13ee1bae35b993e5204ab0f90cc80eaa055605295',
     ),
 
     ServiceTestSpec(
-        "data", True, None, {"limit": 100}
+        "data", True, None, {"limit": 100}, "get",
+        'e1eae0b86148df69173cb3b824275ea73c9c93967f7d17d6957fcdd299c8a4fe',
     ),
 
-    ServiceTestSpec(
-        "assess", True, None, {"foo": "bar"}
-    ),
+#     ServiceTestSpec(
+#         "assess", True, {"user_id": "demo_student"}, {"foo": "bar"}, None, 
+            # '0969eed4ca4bf483096393d13ee1bae35b993e5204ab0f90cc80eaa055605295',
+#     ),
+#         $request = [
+#             "items" => [
+#                 [
+#                     "content" => '<span class="learnosity-response question-demoscience1234"></span>',
+#                     "response_ids" => [
+#                         "demoscience1234"
+#                     ],
+#                     "workflow" => "",
+#                     "reference" => "question-demoscience1"
+#                 ],
+#                 [
+#                     "content" => '<span class="learnosity-response question-demoscience5678"></span>',
+#                     "response_ids" => [
+#                         "demoscience5678"
+#                     ],
+#                     "workflow" => "",
+#                     "reference" => "question-demoscience2"
+#                 ]
+#             ],
+#             "ui_style" =>"horizontal",
+#             "name" => "Demo (2 questions)",
+#             "state" => "initial",
+#             "metadata" => [],
+#             "navigation" => [
+#                 "show_next" => true,
+#                 "toc" => true,
+#                 "show_submit" => true,
+#                 "show_save" => false,
+#                 "show_prev" => true,
+#                 "show_title" => true,
+#                 "show_intro" => true,
+#             ],
+#             "time" => [
+#                 "max_time" => 600,
+#                 "limit_type" => "soft",
+#                 "show_pause" => true,
+#                 "warning_time" => 60,
+#                 "show_time" => true
+#             ],
+#             "configuration" => [
+#                 "onsubmit_redirect_url" => "/assessment/",
+#                 "onsave_redirect_url" => "/assessment/",
+#                 "idle_timeout" => true,
+#                 "questionsApiVersion" => "v2"
+#             ],
+#             "questionsApiActivity" => [
+#                 "user_id" => "demo_student",
+#                 "type" => "submit_practice",
+#                 "state" => "initial",
+#                 "id" => "assessdemo",
+#                 "name" => "Assess API - Demo",
+#                 "questions" => [
+#                     [
+#                         "response_id" => "demoscience1234",
+#                         "type" => "sortlist",
+#                         "description" => "In this question, the student needs to sort the events, chronologically earliest to latest.",
+#                         "list" => ["Russian Revolution", "Discovery of the Americas", "Storming of the Bastille", "Battle of Plataea", "Founding of Rome", "First Crusade"],
+#                         "instant_feedback" => true,
+#                         "feedback_attempts" => 2,
+#                         "validation" => [
+#                             "valid_response" => [4, 3, 5, 1, 2, 0],
+#                             "valid_score" => 1,
+#                             "partial_scoring" => true,
+#                             "penalty_score" => -1
+#                         ]
+#                     ],
+#                     [
+#                         "response_id" => "demoscience5678",
+#                         "type" => "highlight",
+#                         "description" => "The student needs to mark one of the flowers anthers in the image.",
+#                         "img_src" => "http://www.learnosity.com/static/img/flower.jpg",
+#                         "line_color" => "rgb(255, 20, 0)",
+#                         "line_width" => "4"
+#                     ]
+#                 ]
+#             ],
+#             "type" => "activity"
+#         ];
 
     ServiceTestSpec(
-        "events", True, None, {"users": [ "a", "b", "c" ] }
+        "events", True, None,
+        {"users": [ "brianmoser", "hankshrader", "jessepinkman", "walterwhite" ] }, None,
+        '20739eed410d54a135e8cb3745628834886ab315bfc01693ce9acc0d14dc98bf'
     ),
 ]
 
@@ -51,9 +134,10 @@ class TestServiceRequests(unittest.TestCase):
     Tests instantiating a request for each service.
     """
 
-    key = 'foo'
-    secret = 'bar'
+    key =  'yis0TYCu7U9V4o7M'
+    secret = '74c5fd430cf1242a527f6223aebd42d30464be22'
     domain = 'localhost'
+    timestamp = '20140626-0528'
 
     def test_init_generate(self):
         for t in ServiceTests:
@@ -61,10 +145,12 @@ class TestServiceRequests(unittest.TestCase):
             security = {
                 'consumer_key': self.key,
                 'domain': self.domain,
+                'timestamp': self.timestamp,
             }
             if t.security is not None:
                 security.update(t.security)
             init = learnosity_sdk.request.Init(
-                t.service, security, self.secret, request=t.request)
+                t.service, security, self.secret, request=t.request, action=t.action)
 
+            self.assertEqual(t.signature, init.generate_signature())
             self.assertTrue(init.generate() is not None)


### PR DESCRIPTION
Strings of users names were passed as Python strings. Python 3 requires
those to be encoded before serialising them to JSON.

Similarly, a string representation of the SHA-256 hash of each user
needs to be explicitely generated.

LRN-18627

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>