### PR TITLE
[VENDOR] Bump urllib3 to fix CVE-2019-11324

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,8 +13,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Example code
 
 ### Security fixes:
-- Bump requests to 2.20.0 (CVE-2018-18074)
-- Bump urllib3 to 1.24.1 (CVE-2018-20060)
+- Bump requests to 2.21.0 (CVE-2018-18074)
+- Bump urllib3 to 1.24.3 (CVE-2018-20060, CVE-2019-11324)
 
 
 ## [v0.2.0] - 2018-10-17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
-requests==2.20.0
-urllib3==1.24.1
+requests==2.21.0
+urllib3==1.24.3


### PR DESCRIPTION
Bumped package urllib3 from 1.24.1 to 1.24.3 to fix the following
security error:
https://nvd.nist.gov/vuln/detail/CVE-2019-11324

Also bumped requests from 2.20.0 to 2.21.0 for compatibility.

LRN-23661



## Checklist

- [ ] Feature
- [ ] Bug
- [x] Security
- [ ] Documentation

- [x] ChangeLog.md updated

- [ ] Tests added
- [ ] All testsuites passed
- [x] `make dist` completed successfully
