### PR TITLE
Do not enfore ASCII encoding for request payload

### DIFF
--- a/learnosity_sdk/request/init.py
+++ b/learnosity_sdk/request/init.py
@@ -118,7 +118,7 @@ class Init(object):
     def generate_request_string(self):
         if self.request is None:
             return None
-        return json.dumps(self.request, separators=(',', ':'))
+        return json.dumps(self.request, separators=(',', ':'), ensure_ascii=False)
 
     def generate_signature(self):
 


### PR DESCRIPTION
Otherwise, non-ASCII characters are escaped and it causes "Signature mismatch" error if the payload contains non-ASCII characters.



## Checklist

- [ ] Feature
- [x] Bug
- [ ] Security
- [ ] Documentation

- [ ] ChangeLog.md updated

- [ ] Tests added
- [ ] All testsuites passed
- [ ] `make dist` completed successfully
