### PR TITLE
LRN-34037 Option 2: Containerise with extra makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON=python3
 VENV=.venv
 VENVPATH=$(VENV)/$(shell uname)-$(shell uname -m)-sdk-python
+VIRTUALENV = $(PYTHON) -m venv
 
 ENV=prod
 REGION=.learnosity.com
@@ -68,7 +69,7 @@ real-clean: clean
 # Python environment and dependencies
 venv: $(VENVPATH)
 $(VENVPATH):
-	unset PYTHONPATH; virtualenv -p$(PYTHON) $(VENVPATH)
+	unset PYTHONPATH; $(VIRTUALENV) $(VENVPATH)
 	$(call venv-activate); \
 		pip install -e .
 

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,12 @@
+PYTHON_VERSION = 3.9
+PWD = $(shell pwd -P)
+DKR = docker container run -t --rm \
+		-v $(PWD):/srv/sdk/python \
+		-v lrn-sdk-python_cache:/root/.cache:z,delegated \
+		-w /srv/sdk/python \
+		-e PYTHON_VERSION=$(PYTHON_VERSION) \
+		-e ENV -e REGION -e VER \
+		python:$(PYTHON_VERSION)
+
+%:
+	$(DKR) make -e $@


### PR DESCRIPTION
## Summary
Add the ability to build and test in a container. The container command is in an external makefile, requiring selection using `-f docker.mk`.

## Pros
* Doesn't change the existing `Makefile`, which is exactly the same whether running locally or in a container
* Added file is also very simple
* Doesn't require extra control variables (LRN_SDK_NO_DOCKER)
* Allows making targets that don't require Python (notably `clean`) without a container
* Safe with Docker in Docker

## Cons
* Easy to forget to add `-f docker.mk`—the choice has to be expressed every time `make` is invoked
* Opt-in rather than opt-out
* Extra file

## Checklist

- [x] Feature
- [ ] Bug
- [ ] Security
- [ ] Documentation

- [ ] ChangeLog.md updated

- [ ] Tests added
- [ ] All testsuites passed
- [ ] `make dist` completed successfully
