### PR TITLE
Fix quickstart tutorial when running via `pip  install learnosity-sdk[quickstart]`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- Fixed quickstart tutorial when installed via pip
+
 ## [v0.3.8] - 2024-05-28
 ### Added
 - Added a quickstart demo for Authoraide API.


### PR DESCRIPTION
This resolves the issue when running the quickstart guide when installinga as a library from the documentation.

```
pip install learnosity-sdk[quickstart]
```

Working now shown below locally in a fresh venv and install from the locally created wheels.

![image](https://github.com/user-attachments/assets/3f4df21c-c600-4754-91e8-47b4adf7e15f)



## Checklist

- [ ] Feature
- [x] Bug
- [ ] Security
- [ ] Documentation

- [ ] ChangeLog.md updated

- [ ] Tests added
- [ ] All testsuites passed
- [ ] `make dist` completed successfully
