### PR TITLE
Check Package Version Matches Release Tag On Deployment

### DIFF
--- a/.github/workflows/dispatch-release-pypi.yml
+++ b/.github/workflows/dispatch-release-pypi.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      # grep exits with a non-zero exit code if a match is not found
+      - name: Check Library Version matches ${{ github.ref_name }}
+        id: check_version
+        run: |
+          grep "${{ github.ref_name }}" learnosity_sdk/_version.py
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@ Alternatively, if you only care about the version you're currently running, you 
 
 # Deploying to PyPi
 
-Run `make release` and follow the instructions to deploy the distributions to PyPi
-
-You will need to be set up as a maintainer in order to do this.
+1. Add a new entry to the [Changelog.md](./ChangeLog.md)
+1. Merge your pull request after approval.
+2. Create a new Release[https://github.com/Learnosity/learnosity-sdk-python/releases] with a new tag, and this tag will
+be used as the new library version. Please autogenerate release notes to show differences.
 
 [Issues]: https://github.com/Learnosity/learnosity-sdk-python/issues/new
 [PRs]: https://github.com/Learnosity/learnosity-sdk-python/compare


### PR DESCRIPTION
## Overview

Proposal to add a **Versio Check** step to the release action to ensure the release git tag version matches `learnosity/_version.py`.

This works well with the new workflow added by @walsh-conor.

## Context

This came out of my initial experience with #80 where after creating a pre-release, it has overwritten v0.3.8 in `PyPI`, as when creating the release, `_version.py` was still used.
https://github.com/Learnosity/learnosity-sdk-python/releases/tag/v0.3.13-pre

This has been added to the documentation for contributing that a version bump is required for release.

Info on what `github.ref_name` is and why it matches for `release` where we create a new tag.
https://github.com/orgs/community/discussions/26686

## Testing

This small step was manually tested in a fork of the project here:
https://github.com/ferdia-sopermaccafraidh-lrn/learnosity-sdk-python

Successful Run where the tag matches:
 https://github.com/ferdia-sopermaccafraidh-lrn/learnosity-sdk-python/actions/runs/10992052191/job/30515674757
![image](https://github.com/user-attachments/assets/aeeb1690-d9b9-481d-970a-3ff602578d20)

Failed Run where the reference didn't match (on a push so the ref_name was `master`).
https://github.com/ferdia-sopermaccafraidh-lrn/learnosity-sdk-python/actions/runs/10992018237/job/30515573917
![image](https://github.com/user-attachments/assets/4844d3d0-c984-47d2-b377-71caeb0beab5)

## Changes
- **[FEATURE] Check that package version matches release version.**
- **[DOC] Updated release instructions to reflect changes.**

## Checklist
- [x] Feature
- [x] ChangeLog.md updated