### PR TITLE
[FEATURE] Add py.typed marker for type checkers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.3.10] - 2024-10-16
 ### Security
 - Bump certifi minimum version to 2024.07.04
+
+### Added
+- Add py.typed marker for usage with type checkers
 
 ## [v0.3.9] - 2024-08-29
 ### Added


### PR DESCRIPTION
The `py.typed` acts as a marker for type checkers that the type annotations can be used.

This needs to be enabled to take better advantage of type hinting in our own application code.

Ref: https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-type-information
> Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well.

## Testing

Tested locally by install the `learnosity_sdk` before and after the py.typed marker within application code and running `mypy` to ensure it would pick it up

Before change:
```
Skipping analyzing "learnosity_sdk": module is installed, but missing library stubs or py.typed marker  [import-untyped]
See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 66 source files)
```

After change:
```
Success: no issues found in 66 source files
```


## Checklist

- [X] Feature
- [ ] Bug
- [ ] Security
- [ ] Documentation

- [X] ChangeLog.md updated

- [ ] Tests added
- [ ] All testsuites passed
- [x] `make dist` completed successfully
