### PR TITLE
[CLEANUP] Remove Travis (LRN-51188)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Removed Travis CI badge from README as Travis is no longer in use.
+
 ## [v0.3.13] - 2026-01-08
 ### Added
 - Added SDK language and version to request metadata

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 An official Learnosity open-source project.</p>
 
 [![Latest Stable Version](https://badge.fury.io/gh/Learnosity%2Flearnosity-sdk-python.svg)](https://pypi.org/project/learnosity_sdk/)
-[![Build Status](https://app.travis-ci.com/Learnosity/learnosity-sdk-python.svg?branch=master)](https://app.travis-ci.com/Learnosity/learnosity-sdk-python)
 [![License](https://github.com/Learnosity/learnosity-sdk-python/raw/master/docs/images/apache-license.svg)](https://github.com/Learnosity/learnosity-sdk-python/blob/master/LICENSE.md)
 [![Downloads](https://github.com/Learnosity/learnosity-sdk-python/raw/master/docs/images/downloads.svg)](https://github.com/Learnosity/learnosity-sdk-python/releases)
 ---


### PR DESCRIPTION
Removes the Travis CI build status badge from  README.md as Travis is no longer in use at the organisation. No other Travis references were found in the codebase.

